### PR TITLE
Corrige bug no PatientController

### DIFF
--- a/app/Http/Controllers/PatientController.php
+++ b/app/Http/Controllers/PatientController.php
@@ -73,12 +73,12 @@ class PatientController extends Controller
         }
 
         // Salvar o conteúdo no arquivo
-        $filePath = '\pacientes.txt';
+        $filePath = 'pacientes.txt';
         Storage::disk('public')->put($filePath, $content);
 
         // Verifique se o arquivo foi criado
         if (Storage::disk('public')->exists($filePath)) {
-            return response()->download(storage_path("\app\public\pacientes.txt"));
+            return response()->download(storage_path("app/public/" . $filePath));
         } else {
             return response()->json(['error' => 'O arquivo não pôde ser criado.'], 500);
         }


### PR DESCRIPTION
## Summary
- fix bad file path when exporting patients

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684766fa604c833292e7f6b5e3a1aec7